### PR TITLE
Removed recreation of index by default

### DIFF
--- a/api/conf/application.conf
+++ b/api/conf/application.conf
@@ -294,6 +294,7 @@ play.filters {
 
 env.local = ${env.default} {
 
+  elastic.recreate.index = true
   elasticsearch.bi.name = "bi-dev"
   elasticsearch.local = false // true if you want elastic in the same JVM - test mode
   elasticsearch.uri = "elasticsearch://localhost:9300"
@@ -303,7 +304,7 @@ env.local = ${env.default} {
 
 env.default {
   # duplicated config ...
-  elastic.recreate.index = true
+  elastic.recreate.index = false
 
   elasticsearch.bi.name = ${?ONS_BI_API_INDEX_NAME}
   elasticsearch.local = false


### PR DESCRIPTION
- Removed recreation of index by default
- Index is recreated when -Denvironment=local is passed as a parameter
to SBT