### PR TITLE
Fix running instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The last command runs an interactive Elasticsearch 2.4.1 session that the applic
 To compile, build and run the application (by default it will connect to your local ElasticSearch):
 
 ```shell
-sbt api/run -Denvironment=local
+sbt "api/run -Denvironment=local"
 ```
 
 To package the project in a runnable fat-jar:


### PR DESCRIPTION
- Add quotes to start command so that the passed in environment variable can be read in