### PR TITLE
Fix shared Jenkins pipeline branch in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!groovy
-@Library('jenkins-pipeline-shared@feature/new-cf') _
+@Library('jenkins-pipeline-shared@master') _
 
 pipeline {
     environment {


### PR DESCRIPTION
- Use master instead of now removed branch