### PR TITLE
Feature/reg 1421 new es index

### DIFF
--- a/conf/updated_index.json
+++ b/conf/updated_index.json
@@ -1,0 +1,85 @@
+{
+  "settings": {
+    "index": {
+      "analysis": {
+        "analyzer": {
+          "synonym": {
+            "tokenizer": "standard",
+            "filter": [
+              "synonym",
+              "stemmer"
+            ]
+          }
+        },
+        "filter" : {
+          "synonym" : {
+            "type" : "synonym",
+            "synonyms" : [
+              "ltd, limited",
+              "bros, brothers",
+              "public limited company=>plc",
+              "community interest company=>cic",
+              "right to enfranchisement=>rte",
+              "right to manage=>rtm",
+              "european enonomic interest grouping=>eeig",
+              "limited partnership=>lp",
+              "Cwmni Cyfyngedig Cyhoeddus=>ccc",
+              "Cwmni Buddiant Cymunedol=>cbc",
+              "Partneriaeth Cyfyngedig=>pc",
+              "Partneriaeth Atebolrwydd Cyfyngedig=>pac",
+              "Sefydliad Elusennol Corfforedig=>sec",
+              "limited liability partnership=>llp,"
+            ],
+            "ignore_case" : true
+          },
+          "stemmer" : {
+            "type" : "stemmer",
+            "name" : "possessive_english"
+          }
+        }
+      }
+    }
+  },
+  "mappings": {
+    "bi" : {
+      "properties" : {
+        "ID" : {
+          "type" : "string"
+        },
+        "BusinessName" : {
+          "type" : "text"
+        },
+        "UBRN" : {
+          "type" : "string"
+        },
+        "IndustryCode" : {
+          "type" : "long"
+        },
+        "LegalStatus" : {
+          "type" : "keyword"
+        },
+        "TradingStatus" : {
+          "type" : "keyword"
+        },
+        "Turnover" : {
+          "type" : "keyword"
+        },
+        "EmploymentBands" : {
+          "type" : "keyword"
+        },
+        "PostCode" : {
+          "type" : "string"
+        },
+        "VatRefs" : {
+          "type" : "string"
+        },
+        "PayeRefs" : {
+          "type" : "string"
+        },
+        "CompanyNo" : {
+          "type" : "string"
+        }
+      }
+    }
+  }
+}

--- a/conf/updated_index.json
+++ b/conf/updated_index.json
@@ -28,7 +28,7 @@
               "Partneriaeth Cyfyngedig=>pc",
               "Partneriaeth Atebolrwydd Cyfyngedig=>pac",
               "Sefydliad Elusennol Corfforedig=>sec",
-              "limited liability partnership=>llp,"
+              "limited liability partnership=>llp"
             ],
             "ignore_case" : true
           },


### PR DESCRIPTION
- Add updated ElasticSearch index definition JSON based upon code from a [proof of concept](https://github.com/pds2208/bi-ui-flask/blob/master/createIndex.sh)
- Add synonyms from [here](https://github.com/pds2208/bi-ui-flask/blob/master/synonyms.txt) to the JSON definition (an external `.txt` file will be used once testing has been completed)

This index definition will exist alongside the original index definition, so that they can be tested against each other.