### PR TITLE
Add fixed es index definition JSON

### DIFF
--- a/conf/updated_index.json
+++ b/conf/updated_index.json
@@ -47,7 +47,7 @@
           "type" : "string"
         },
         "BusinessName" : {
-          "type" : "text"
+          "type" : "string"
         },
         "UBRN" : {
           "type" : "string"
@@ -56,16 +56,20 @@
           "type" : "long"
         },
         "LegalStatus" : {
-          "type" : "keyword"
+          "type" : "string",
+          "index": "not_analyzed"
         },
         "TradingStatus" : {
-          "type" : "keyword"
+          "type" : "string",
+          "index": "not_analyzed"
         },
         "Turnover" : {
-          "type" : "keyword"
+          "type" : "string",
+          "index": "not_analyzed"
         },
         "EmploymentBands" : {
-          "type" : "keyword"
+          "type" : "string",
+          "index": "not_analyzed"
         },
         "PostCode" : {
           "type" : "string"


### PR DESCRIPTION
Previous index definition worked for ElasticSearch 5.6 but not 2.4, hence the following changes have been made:
- Change `keyword` -> `string` + `not_analyzed` (effectively the same as `keyword`)
- Change `text` -> `string`