### PR TITLE
Punctuation will be removed from Elastic Search index

### DIFF
--- a/conf/updated_index.json
+++ b/conf/updated_index.json
@@ -5,7 +5,7 @@
         "analyzer": {
           "synonym": {
             "tokenizer": "standard",
-            "filter": ["synonym", "uppercase"],
+            "filter": ["synonym"],
             "char_filter" : ["my_char_filter"]
           }
         },
@@ -29,10 +29,6 @@
               "limited liability partnership=>llp"
             ],
             "ignore_case" : true
-          },
-          "stemmer" : {
-            "type" : "stemmer",
-            "name" : "possessive_english"
           }
         },
         "char_filter" : {
@@ -50,7 +46,6 @@
               "!=>",
               "?=>",
               "/=>",
-              "!=>",
               "@=>",
               "$=>",
               "£=>",
@@ -64,6 +59,7 @@
               ":=>",
               ";=>",
               "*=>",
+              "'=>",
               "\\u0091=>",
               "\\u0092=>",
               "\\u2018=>",

--- a/conf/updated_index.json
+++ b/conf/updated_index.json
@@ -5,10 +5,8 @@
         "analyzer": {
           "synonym": {
             "tokenizer": "standard",
-            "filter": [
-              "synonym",
-              "stemmer"
-            ]
+            "filter": ["synonym", "uppercase"],
+            "char_filter" : ["my_char_filter"]
           }
         },
         "filter" : {
@@ -36,6 +34,46 @@
             "type" : "stemmer",
             "name" : "possessive_english"
           }
+        },
+        "char_filter" : {
+          "my_char_filter" : {
+            "type" : "mapping",
+            "mappings" : [
+              ".=>",
+              ",=>",
+              "(=>",
+              ")=>",
+              "[=>",
+              "]=>",
+              "{=>",
+              "}=>",
+              "!=>",
+              "?=>",
+              "/=>",
+              "!=>",
+              "@=>",
+              "$=>",
+              "£=>",
+              "%=>",
+              "~=>",
+              "^=>",
+              "€=>",
+              "#=>",
+              "-=>",
+              "_=>",
+              ":=>",
+              ";=>",
+              "*=>",
+              "\\u0091=>",
+              "\\u0092=>",
+              "\\u2018=>",
+              "\\u2019=>",
+              "\\u201B=>",
+              "\\u0022=>",
+              "\\u201C=>",
+              "\\u201D=>"
+            ]
+          }
         }
       }
     }
@@ -47,7 +85,8 @@
           "type" : "string"
         },
         "BusinessName" : {
-          "type" : "string"
+          "type" : "string",
+          "analyzer":"synonym"
         },
         "UBRN" : {
           "type" : "string"


### PR DESCRIPTION
New Elastic Search index to fulfil the requirements of REG-120.

Punctuation removed has a link to a confluence page on the REG-120 JIRA story.